### PR TITLE
Replace write with binwrite

### DIFF
--- a/lib/oops_logger/server.ex
+++ b/lib/oops_logger/server.ex
@@ -53,7 +53,7 @@ defmodule OopsLogger.Server do
 
   def handle_cast({:log, level, message}, %State{fd: fd, format: format} = state) do
     output = apply_format(format, level, message)
-    IO.write(fd, output)
+    IO.binwrite(fd, output)
     {:noreply, state}
   end
 


### PR DESCRIPTION
This prevents the logger from crashing if bad Unicode is sent to it. The
assumption is that the log message is more valuable corrupt than
dropped so let it pass through.