### PR TITLE
Add missing gen_event functions

### DIFF
--- a/lib/ramoops_logger.ex
+++ b/lib/ramoops_logger.ex
@@ -149,6 +149,16 @@ defmodule RamoopsLogger do
   end
 
   @impl :gen_event
+  def handle_info(_, state) do
+    {:ok, state}
+  end
+
+  @impl :gen_event
+  def code_change(_old_vsn, state, _extra) do
+    {:ok, state}
+  end
+
+  @impl :gen_event
   def terminate(_reason, state) do
     Server.stop(state)
   end


### PR DESCRIPTION
This fixes the following:

```
** Undefined handle_info in 'Elixir.RamoopsLogger'
** Unhandled message: {'Elixir.Logger.Config',update_counter}
```
