### PR TITLE
Update Elixir 1.17 CI image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ tags: &tags
     1.20.0-erlang-29.0.1-alpine-3.23.4,
     1.19.3-erlang-28.1.1-alpine-3.22.2,
     1.18.4-erlang-27.3.4.3-alpine-3.22.1,
-    1.17.3-erlang-27.3.3-alpine-3.21.3
+    1.17.3-erlang-27.3.4.16-alpine-3.24.1
   ]
 
 jobs:


### PR DESCRIPTION
Update the Elixir 1.17 CircleCI image to OTP 27.3.4.16 and Alpine 3.24.1. This avoids an OTP 27 bug that is causing CI failures.